### PR TITLE
Fix hidden files push

### DIFF
--- a/src/jobs/push.yml
+++ b/src/jobs/push.yml
@@ -59,7 +59,7 @@ steps:
       working_directory: stoplight
       command: |
         find . -path ./.git -prune -o -exec rm -rf {} \; 2> /dev/null
-        cp -r ../source/<<parameters.source_dir>>/* .
+        cp -r ../source/<<parameters.source_dir>>/. .
         git add .
         git diff-index --quiet HEAD || git commit -m "Update API docs with $CIRCLE_SHA1"
         git push origin $STOPLIGHT_REPO_BRANCH


### PR DESCRIPTION
Fixes a bug that would cause hidden files such as `.stoplight.yml` not to be pushed to the Stoplight repository due to how the `cp` call is structured.