### PR TITLE
Fix CircleCI workspace download failure

### DIFF
--- a/src/jobs/push.yml
+++ b/src/jobs/push.yml
@@ -39,14 +39,14 @@ parameters:
 executor: default
 
 steps:
-  - attach_workspace:
-      at: /tmp/workspace
   - run:
-      name: Set up Git
+      name: Set up SSL and Git
       command: |
-        apt-get update && apt-get install -y git
+        apt-get update && apt-get install -y git ca-certificates
         git config --global user.name "<<parameters.git_name>>"
         git config --global user.email "<<parameters.git_email>>"
+  - attach_workspace:
+      at: /tmp/workspace
   - checkout:
       path: source
   - run:


### PR DESCRIPTION
Installs `ca-certificates` in the CircleCI image in order to fix a failure while downloading the build workspace. For more info, see https://support.circleci.com/hc/en-us/articles/360016505753-Resolve-Certificate-Signed-By-Unknown-Authority-error-in-Alpine-images.